### PR TITLE
Fixes CMakeLists.txt to properly import the paths into any location. pico-sdk compatible.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,14 +1,14 @@
 
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp")
 
-add_library(TcMenuLog INTERFACE ${SOURCES})
+add_library(TcMenuLog ${SOURCES})
 
 target_compile_definitions(TcMenuLog
-        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(TcMenuLog INTERFACE
+target_include_directories(TcMenuLog PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(TcMenuLog INTERFACE pico_stdlib pico_sync)
+target_link_libraries(TcMenuLog PUBLIC pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,14 +1,14 @@
-add_library(TcMenuLog
-        ../src/IoLogging.cpp
-        ../src/TextUtilities.cpp
-)
+
+file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp")
+
+add_library(TcMenuLog ${SOURCES})
 
 target_compile_definitions(TcMenuLog
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
 target_include_directories(TcMenuLog PUBLIC
-        ${PROJECT_SOURCE_DIR}/lib/TcMenuLog/src
+        ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
 target_link_libraries(TcMenuLog PUBLIC pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,14 +1,14 @@
 
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp")
 
-add_library(TcMenuLog ${SOURCES})
+add_library(TcMenuLog INTERFACE ${SOURCES})
 
 target_compile_definitions(TcMenuLog
-        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(TcMenuLog PUBLIC
+target_include_directories(TcMenuLog INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(TcMenuLog PUBLIC pico_stdlib pico_sync)
+target_link_libraries(TcMenuLog INTERFACE pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,14 +1,16 @@
+cmake_minimum_required(VERSION 3.13)
 
-file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp")
-
-add_library(TcMenuLog ${SOURCES})
+add_library(TcMenuLog 
+        ../src/IoLogging.cpp
+        ../src/TextUtilities.cpp
+)
 
 target_compile_definitions(TcMenuLog
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
 target_include_directories(TcMenuLog PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/../src
+        ../src
 )
 
 target_link_libraries(TcMenuLog PUBLIC pico_stdlib pico_sync)

--- a/src/PrintCompat.h
+++ b/src/PrintCompat.h
@@ -6,7 +6,7 @@
 #define IOA_PRINT_COMPAT_H
 
 #include <cstdlib>
-#include <TextUtilities.h>
+#include "TextUtilities.h"
 #include <inttypes.h>
 
 /**


### PR DESCRIPTION
In trying out the tcMenu, i found it not easy to use as the libraries had to be exported and pushed into very specific locations. Having done cmake libraries for the pico-sdk, I was able to make the required changes to properly import the sdk using cmake.

The `CMakeLists.txt` has had the paths fixed,  so that it can be used with the `libraries.cmake` that is in the `tcLibraryDev` or `FetchContent`  from cmake.